### PR TITLE
guide compatability with ggplot2 >3.4.2

### DIFF
--- a/R/brackets.R
+++ b/R/brackets.R
@@ -60,8 +60,7 @@ brackets_horizontal <- function(direction = c('up','down'),
 
   # Returns a function
   fn <- function(guides, position, theme) {
-    guide <- guide_for_position(guides, position)
-    agrob <- guide_gengrob(guide, theme)
+    agrob <- panel_guides_grob(guides, position, theme)
     if (agrob$name == 'NULL') return(agrob)
 
     ind <- names(agrob$children) == 'axis'
@@ -142,8 +141,7 @@ brackets_vertical <- function(direction = c('left','right'),
 
   direction=match.arg(direction)
   fn <- function(guides, position, theme) {
-    guide <- guide_for_position(guides, position)
-    agrob <- guide_gengrob(guide, theme)
+    agrob <- panel_guides_grob(guides, position, theme)
     if (agrob$name == 'NULL') return(agrob)
 
     ind <- names(agrob$children) == 'axis'

--- a/R/coord-capped.r
+++ b/R/coord-capped.r
@@ -129,7 +129,8 @@ capped_horizontal <- function(capped = c('both','left','right','none'),
   # theme:
   fn <- function(guides, position, theme) {
     guide <- guide_for_position(guides, position)
-    agrob <- guide_gengrob(guide, theme)
+    agrob <- panel_guides_grob(guides, position, theme)
+
     if (agrob$name == 'NULL') return(agrob)
 
     r <- range(guide$key$x)
@@ -162,8 +163,9 @@ capped_vertical <- function(capped = c('top','bottom','both','none'),
   # position: top or bottom / left or right
   # theme:
   fn <- function(guides, position, theme) {
-    guide <- guide_for_position(guides, position) #guides[[which(sapply(guides, `[[`, 'position') == position)]]
-    agrob <- guide_gengrob(guide, theme)
+    guide <- guide_for_position(guides, position)
+    agrob <- panel_guides_grob(guides, position, theme)
+
     if (agrob$name == 'NULL') return(agrob)
 
     r <- range(guide$key$y)

--- a/R/ggplot2.r
+++ b/R/ggplot2.r
@@ -71,16 +71,30 @@ is.zero <- function (x)  {
 
 # From ggplot2/R/coord-cartesian-.r
 panel_guide_label <- function(guides, position, default_label) {
-  guide <- guide_for_position(guides, position) %||% guide_none(title = waiver())
-  guide$title %|W|% default_label
+  if (inherits(guides, "Guides")) {
+    pair <- guides$get_position(position)
+    pair$params$title %|W|% default_label
+  } else {
+    guide <- guide_for_position(guides, position) %||% guide_none(title = waiver())
+    guide$title %|W|% default_label
+  }
 }
 
 panel_guides_grob <- function(guides, position, theme) {
-  guide <- guide_for_position(guides, position) %||% guide_none()
-  guide_gengrob(guide, theme)
+  if (inherits(guides, "Guides")) {
+    pair <- guides$get_position(position)
+    pair$guide$draw(theme, pair$params)
+  } else {
+    guide <- guide_for_position(guides, position) %||% guide_none()
+    guide_gengrob(guide, theme)
+  }
 }
 
 guide_for_position <- function(guides, position) {
+  if (inherits(guides, "Guides")) {
+    pair <- guides$get_position(position)
+    return(pair$params)
+  }
   has_position <- vapply(
     guides,
     function(guide) identical(guide$position, position),


### PR DESCRIPTION
Hi Stefan,

Apologies for the cold PR without posting an issue first. 
The ggplot2 package has changed the implementation of the guide system, which means that the old S3 system will no longer work, see ggplot2's [news file](https://github.com/tidyverse/ggplot2/blob/2a7ca74e297cdc23c56ce34fef193d5a6b488292/NEWS.md?plain=1#L29-L59).

Unfortunately, these changes aren't fully backwards compatible, so packages implementing custom guides will need a few tweaks. This PR provides these tweaks for lemon. It is currently still work in progress (WIP) as I'm still trying to figure out what changes in ggplot2 would make the transition easier.

Best,
Teun