### PR TITLE
update `panel_guides_grob()`

### DIFF
--- a/R/ggplot2.r
+++ b/R/ggplot2.r
@@ -79,10 +79,11 @@ panel_guide_label <- function(guides, position, default_label) {
   }
 }
 
-panel_guides_grob <- function(guides, position, theme) {
+panel_guides_grob <- function(guides, position, theme, labels = NULL) {
   if (inherits(guides, "Guides")) {
     pair <- guides$get_position(position)
-    pair$guide$draw(theme, pair$params)
+    pair$params$draw_label <- labels
+    pair$guide$draw(theme, params = pair$params)
   } else {
     guide <- guide_for_position(guides, position) %||% guide_none()
     guide_gengrob(guide, theme)


### PR DESCRIPTION
Hi Stefan,

This is a follow-up on #30. We have been preparing a new release of ggplot2 and during a reverse dependency check it became apparent that the prospective ggplot2 3.5.0 would break lemon. As the person responsible for the breakage, I thought I might help out with a PR.

Since implementing #30 we have slightly changed the mechanism in `panel_guides_grob()`. This PR reflects these changes in the one used by lemon. To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled at the end of January / early Februari. The progress can be tracked in https://github.com/tidyverse/ggplot2/issues/5588.