### PR TITLE
Compatibility with ggplot2 4.0.0

### DIFF
--- a/R/brackets.R
+++ b/R/brackets.R
@@ -77,7 +77,7 @@ brackets_horizontal <- function(direction = c('up','down'),
 
       x <- rep(ticksgrob$x, each = 2) +
         rep(unit.c(length * -1, length * -1, length, length ), times = nticks)
-      tick.length <- tick.length %|W|% theme$axis.ticks.length
+      tick.length <- tick.length %|W|% calc_element("axis.ticks.length", theme)
       y0 <-  unit.c(unit(1, 'npc'), unit(1, 'npc') - tick.length)
       d <- switch(direction, down = c(2, 1, 1, 2), up=c(1, 2, 2, 1))
       y <- rep(y0[d], times = nticks)
@@ -162,7 +162,7 @@ brackets_vertical <- function(direction = c('left','right'),
 
       y <- rep(ticksgrob$y, each = 2) +
         rep(unit.c(length * -1, length * -1, length, length ), times = nticks)
-      tick.length <- tick.length %|W|% theme$axis.ticks.length
+      tick.length <- tick.length %|W|% calc_element("axis.ticks.length", theme)
       x0 <-  unit.c(unit(1, 'npc'), unit(1, 'npc') - tick.length)
       d <- switch(direction, left = c(2, 1, 1, 2), right=c(1, 2, 2, 1))
       x <- rep(x0[d], times = nticks)

--- a/R/facet-rep-lab.r
+++ b/R/facet-rep-lab.r
@@ -73,10 +73,12 @@ remove_labels_from_axis <- function(axisgrob, direction = c('horizontal','vertic
     axis <- axisgrob$children[[a]]
     axis$grobs[[d]] <- zeroGrob()
     if (direction == 'horizontal') {
-      axis$heights[[d]] <- unit(0,'npc')
+      i <- unique(axis$layout$t[d])
+      axis$heights[i] <- unit(0,'cm')
       axisgrob$height <- sum(axis$heights)
     } else if (direction == 'vertical') {
-      axis$widths[[d]] <- unit(0,'npc')
+      i <- unique(axis$layout$l[d])
+      axis$widths[i] <- unit(0,'cm')
       axisgrob$width <- sum(axis$widths)
     }
     axisgrob$children[[a]] <- axis

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -90,9 +90,9 @@ FacetWrapRepeatLabels <- ggplot2::ggproto('FacetWrapRepeatLabels',
     panel_table$layout$name <- paste0('panel-', rep(seq_len(ncol), nrow), '-', rep(seq_len(nrow), each = ncol))
 
     panel_table <- gtable::gtable_add_col_space(panel_table,
-      theme$panel.spacing.x %||% theme$panel.spacing)
+      calc_element("panel.spacing.x", theme))
     panel_table <- gtable::gtable_add_row_space(panel_table,
-      theme$panel.spacing.y %||% theme$panel.spacing)
+      calc_element("panel.spacing.y", theme))
 
     # Add axes
     axis_mat_x_top <- empty_table


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The main issue we found is that sometimes `theme$element_name` was used on elements that remained unresolved (they could be `"rel"` objects instead of units, for example). Using `calc_element()` resolves such cases.

Aside from this issue, I also was surprised by some panel spacing in facets that seemed to include space for labels that were removed, so I took the liberty of adapting your axis measurement code. It should now more tightly measure the axes. I've not touched the visual snapshots, so you can judge for yourself.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun